### PR TITLE
fix: RSS Feed のファイルが壊れるのを修正

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 lang: ja-JP
-title: '<a href="https://jiro4989.github.io/" style="color:white">次郎の貝塚</a>'
-description: '技術ブログのような何か | <a href="/feed.xml" target="_blank">RSS</a>'
+title: '次郎の貝塚'
+description: '技術ブログのような何か'
 author: jiro4989
 remote_theme: pages-themes/slate@v0.2.0
 plugins:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,maximum-scale=2">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+
+{% seo %}
+    {% include head-custom.html %}
+  </head>
+
+  <body>
+
+    <!-- HEADER -->
+    <div id="header_wrap" class="outer">
+        <header class="inner">
+          {% if site.github.is_project_page %}
+            <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
+          {% endif %}
+
+          <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
+          <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
+
+          {% if site.show_downloads %}
+            <section id="downloads">
+              <a class="zip_download_link" href="{{ site.github.zip_url }}">Download this project as a .zip file</a>
+              <a class="tar_download_link" href="{{ site.github.tar_url }}">Download this project as a tar.gz file</a>
+            </section>
+          {% endif %}
+        </header>
+    </div>
+
+    <!-- MAIN CONTENT -->
+    <div id="main_content_wrap" class="outer">
+      <section id="main_content" class="inner">
+        {{ content }}
+      </section>
+    </div>
+
+    <!-- FOOTER  -->
+    <div id="footer_wrap" class="outer">
+      <footer class="inner">
+        {% if site.github.is_project_page %}
+        <p class="copyright">{{ site.title | default: site.github.repository_name }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+        {% endif %}
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,8 +20,8 @@
             <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
           {% endif %}
 
-          <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
-          <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
+          <h1 id="project_title"><a href="https://jiro4989.github.io/" style="color:white">{{ site.title | default: site.github.repository_name }}</a></h1>
+          <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }} | <a href="/feed.xml" target="_blank">RSS</a></h2>
 
           {% if site.show_downloads %}
             <section id="downloads">


### PR DESCRIPTION
無理くり `_config.yml` にHTMLを埋め込むと RSS Feed の XML の方がこんな感じになってしまう。
title, description に HTML タグが埋め込まれてしまう。
流石にこれは奇妙なので、素直に元の layout html ファイルを修正することにした。

```xml
<generator uri="https://jekyllrb.com/" version="3.9.3">Jekyll</generator>
<link href="https://jiro4989.github.io/feed.xml" rel="self" type="application/atom+xml"/>
<link href="https://jiro4989.github.io/" rel="alternate" type="text/html" hreflang="ja-JP"/>
<updated>2023-10-25T16:41:05+00:00</updated>
<id>https://jiro4989.github.io/feed.xml</id>
<title type="html"><a href="https://jiro4989.github.io/" style="color:white">次郎の貝塚</a></title>
<subtitle>技術ブログのような何か | <a href="/feed.xml" target="_blank">RSS</a></subtitle>
```